### PR TITLE
build: move .env management to buildSrc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ allprojects {
         }
     }
 
-    if (!inCI()) {
+    if (!inCI) {
         injectInto(JavaExec::class, Test::class) environmentsFrom rootProject.dotenv
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import DotenvUtils.dotenv
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
@@ -6,24 +7,6 @@ plugins {
     id("scala")
     alias(libs.plugins.scala.extras)
 }
-
-class DotenvConfiguration(private val fileName: String = DEFAULT_ENV_FILE_NAME) {
-
-    fun environmentVariables(): Map<String, String> =
-        rootDir.resolve(fileName)
-            .takeIf { it.exists() }
-            ?.readLines()
-            ?.filter { it.isNotBlank() && !it.startsWith(COMMENT_SYMBOL) }
-            ?.associate { it.split(KEY_VALUE_SEPARATOR).let { (key, value) -> key to value } }
-            ?: emptyMap()
-
-    companion object {
-        private const val DEFAULT_ENV_FILE_NAME = ".env"
-        private const val COMMENT_SYMBOL = "#"
-        private const val KEY_VALUE_SEPARATOR = "="
-    }
-}
-val dotenvConfig = DotenvConfiguration()
 
 allprojects {
     group = "io.github.positionpal"
@@ -60,10 +43,10 @@ allprojects {
     }
 
     tasks.withType<JavaExec> {
-        dotenvConfig.environmentVariables().forEach { environment(it.key, it.value) }
+        rootProject.dotenv().environmentVariables().forEach { environment(it.key, it.value) }
     }
 
     tasks.withType<Test> {
-        dotenvConfig.environmentVariables().forEach { environment(it.key, it.value) }
+        rootProject.dotenv().environmentVariables().forEach { environment(it.key, it.value) }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 import DotenvUtils.dotenv
+import DotenvUtils.injectInto
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import kotlin.reflect.KClass
 
 plugins {
     `java-library`
@@ -42,11 +44,5 @@ allprojects {
         }
     }
 
-    tasks.withType<JavaExec> {
-        rootProject.dotenv().environmentVariables().forEach { environment(it.key, it.value) }
-    }
-
-    tasks.withType<Test> {
-        rootProject.dotenv().environmentVariables().forEach { environment(it.key, it.value) }
-    }
+    injectInto(JavaExec::class, Test::class) environmentsFrom rootProject.dotenv
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 import DotenvUtils.dotenv
 import DotenvUtils.injectInto
+import Utils.inCI
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
-import kotlin.reflect.KClass
 
 plugins {
     `java-library`
@@ -44,5 +44,7 @@ allprojects {
         }
     }
 
-    injectInto(JavaExec::class, Test::class) environmentsFrom rootProject.dotenv
+    if (!inCI()) {
+        injectInto(JavaExec::class, Test::class) environmentsFrom rootProject.dotenv
+    }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}

--- a/buildSrc/src/main/kotlin/DotenvUtils.kt
+++ b/buildSrc/src/main/kotlin/DotenvUtils.kt
@@ -9,15 +9,12 @@ object DotenvUtils {
     val Project.dotenv: DotEnv
         get() = DotEnv.from(file(".env"))
 
-    fun <T> Project.injectInto(vararg taskTypes: KClass<out T>): ProcessForkOptionConfigurator where T : Task, T : ProcessForkOptions {
-        val forkOptionsList = mutableListOf<ProcessForkOptions>()
-        taskTypes.forEach { taskType ->
-            tasks.withType(taskType.java).all { task ->
-                forkOptionsList.add(task)
+    fun <T> Project.injectInto(vararg taskTypes: KClass<out T>) where T : Task, T : ProcessForkOptions =
+        ProcessForkOptionConfigurator(
+            taskTypes.flatMap { taskType ->
+                tasks.withType(taskType.java).map { it as ProcessForkOptions }
             }
-        }
-        return ProcessForkOptionConfigurator(forkOptionsList)
-    }
+        )
 
     fun injectInto(pfo: ProcessForkOptions) = ProcessForkOptionConfigurator(listOf(pfo))
 

--- a/buildSrc/src/main/kotlin/DotenvUtils.kt
+++ b/buildSrc/src/main/kotlin/DotenvUtils.kt
@@ -11,16 +11,15 @@ object DotenvUtils {
 
     fun <T> Project.injectInto(vararg taskTypes: KClass<out T>) where T : Task, T : ProcessForkOptions =
         ProcessForkOptionConfigurator(
-            taskTypes.flatMap { taskType ->
-                tasks.withType(taskType.java).map { it as ProcessForkOptions }
-            }
+            taskTypes.flatMap { tasks.withType(it.java) }
         )
 
-    fun injectInto(pfo: ProcessForkOptions) = ProcessForkOptionConfigurator(listOf(pfo))
-
-    class ProcessForkOptionConfigurator(private val pfo: List<ProcessForkOptions>) {
-        infix fun environmentsFrom(dotenv: DotEnv) =
-            dotenv.variables().forEach { (key, value) -> pfo.forEach { it.environment(key, value) } }
+    class ProcessForkOptionConfigurator<T>(private val pfo: List<T>) where T : Task, T : ProcessForkOptions {
+        infix fun environmentsFrom(dotenv: DotEnv) = pfo.forEach {
+            it.doFirst {
+                dotenv.variables().forEach { (key, value) -> it.environment(key, value) }
+            }
+        }
     }
 
     interface DotEnv {

--- a/buildSrc/src/main/kotlin/DotenvUtils.kt
+++ b/buildSrc/src/main/kotlin/DotenvUtils.kt
@@ -1,7 +1,10 @@
 import org.gradle.api.Project
+import org.gradle.process.ProcessForkOptions
 import java.io.File
 
-object Utils {
+object DotenvUtils {
+
+    fun Project.dotenv(): DotenvConfiguration = DotenvConfiguration(projectDir)
 
     class DotenvConfiguration(private val rootDir: File, private val fileName: String = DEFAULT_ENV_FILE_NAME) {
 
@@ -13,13 +16,13 @@ object Utils {
                 ?.associate { it.split(KEY_VALUE_SEPARATOR).let { (key, value) -> key to value } }
                 ?: emptyMap()
 
+        fun applyTo(vararg pfo: ProcessForkOptions) =
+            environmentVariables().forEach { (key, value) -> pfo.forEach { it.environment(key, value) } }
+
         companion object {
             private const val DEFAULT_ENV_FILE_NAME = ".env"
             private const val COMMENT_SYMBOL = "#"
             private const val KEY_VALUE_SEPARATOR = "="
         }
     }
-
-    fun Project.envs() = DotenvConfiguration(projectDir).environmentVariables()
-
 }

--- a/buildSrc/src/main/kotlin/DotenvUtils.kt
+++ b/buildSrc/src/main/kotlin/DotenvUtils.kt
@@ -14,8 +14,8 @@ object DotenvUtils {
             taskTypes.flatMap { tasks.withType(it.java) }
         )
 
-    class ProcessForkOptionConfigurator<T>(private val pfo: List<T>) where T : Task, T : ProcessForkOptions {
-        infix fun environmentsFrom(dotenv: DotEnv) = pfo.forEach {
+    class ProcessForkOptionConfigurator<T>(private val taskTypes: List<T>) where T : Task, T : ProcessForkOptions {
+        infix fun environmentsFrom(dotenv: DotEnv) = taskTypes.forEach {
             it.doFirst {
                 dotenv.variables().forEach { (key, value) -> it.environment(key, value) }
             }

--- a/buildSrc/src/main/kotlin/Utils.kt
+++ b/buildSrc/src/main/kotlin/Utils.kt
@@ -1,0 +1,25 @@
+import org.gradle.api.Project
+import java.io.File
+
+object Utils {
+
+    class DotenvConfiguration(private val rootDir: File, private val fileName: String = DEFAULT_ENV_FILE_NAME) {
+
+        fun environmentVariables(): Map<String, String> =
+            rootDir.resolve(fileName)
+                .takeIf { it.exists() }
+                ?.readLines()
+                ?.filter { it.isNotBlank() && !it.startsWith(COMMENT_SYMBOL) }
+                ?.associate { it.split(KEY_VALUE_SEPARATOR).let { (key, value) -> key to value } }
+                ?: emptyMap()
+
+        companion object {
+            private const val DEFAULT_ENV_FILE_NAME = ".env"
+            private const val COMMENT_SYMBOL = "#"
+            private const val KEY_VALUE_SEPARATOR = "="
+        }
+    }
+
+    fun Project.envs() = DotenvConfiguration(projectDir).environmentVariables()
+
+}

--- a/buildSrc/src/main/kotlin/Utils.kt
+++ b/buildSrc/src/main/kotlin/Utils.kt
@@ -1,0 +1,4 @@
+object Utils {
+
+    fun inCI(): Boolean = System.getenv()["CI"].equals("true", ignoreCase = true)
+}

--- a/buildSrc/src/main/kotlin/Utils.kt
+++ b/buildSrc/src/main/kotlin/Utils.kt
@@ -1,4 +1,5 @@
 object Utils {
 
-    fun inCI(): Boolean = System.getenv()["CI"].equals("true", ignoreCase = true)
+    val inCI: Boolean
+        get() = System.getenv()["CI"].equals("true", ignoreCase = true)
 }


### PR DESCRIPTION
This PR refactors the management of `.env` files by moving imperative-like code into `buildSrc`, ensuring that the build file remains declarative and cleaner.