### PR TITLE
test(infrastructure): override default futures completion patience configuration and move in site call the eventually patience params

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,23 +15,19 @@ jobs:
     permissions:
       contents: read
       packages: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,4 +43,3 @@ jobs:
     with:
       container_version: ${{ needs.release.outputs.container_version }}
     secrets: inherit
-

--- a/infrastructure/src/test/scala/io/github/positionpal/location/infrastructure/ws/WebSocketsTest.scala
+++ b/infrastructure/src/test/scala/io/github/positionpal/location/infrastructure/ws/WebSocketsTest.scala
@@ -21,7 +21,7 @@ class WebSocketsTest extends AnyWordSpecLike with Matchers with WebSocketTestDSL
   private val config = WebSocketTestConfig(baseEndpoint = "ws://localhost:8080/group", connectionTimeout = 5.seconds)
   private val systemResource = EndOfWorld.startup(8080)(ConfigFactory.load("akka.conf"))
 
-  given Eventually.PatienceConfig = Eventually.PatienceConfig(Span(30, Seconds), Span(500, Milliseconds))
+  given patience: PatienceConfig = PatienceConfig(timeout = Span(5, Seconds), interval = Span(100, Milliseconds))
 
   "WebSocket clients" when:
     "attempting to connect the web socket backend service" should:
@@ -49,7 +49,7 @@ class WebSocketsTest extends AnyWordSpecLike with Matchers with WebSocketTestDSL
             val result = test.runTest(scenario)
             whenReady(result): combinedConnectionsResult =>
               combinedConnectionsResult shouldBe true
-              eventually:
+              eventually(timeout(Span(30, Seconds)), interval(Span(500, Milliseconds))):
                 scenario.clients.foreach:
                   _.responses should contain allElementsOf expectedEvents
         .unsafeRunSync()


### PR DESCRIPTION
Too strict timeout in the default scala test futures patience configuration caused web socket connection test fail on CI (see for example [this run](https://github.com/position-pal/location-service/actions/runs/11837277601/job/32983934981?pr=86#step:6:456)). This PR overrides the default patience config to overcome this issue.