### PR TITLE
feat: add group manager sharded actor for handling group-based updates

### DIFF
--- a/tracking-actors/src/main/scala/io/github/positionpal/location/tracking/ActorBasedRealTimeTracking.scala
+++ b/tracking-actors/src/main/scala/io/github/positionpal/location/tracking/ActorBasedRealTimeTracking.scala
@@ -27,7 +27,9 @@ object ActorBasedRealTimeTracking extends RealTimeTracking:
     ): F[Service[F, Scope]] =
       for
         sharding <- Async[F].delay(ClusterSharding(actorSystem))
-        _ <- Async[F].delay(sharding.init(RealTimeUserTracker(using notificationService, mapsService)))
+        _ <- Async[F].delay:
+          sharding.init(GroupManager())
+          sharding.init(RealTimeUserTracker(using notificationService, mapsService))
       yield ServiceImpl(actorSystem)
 
   private class ServiceImpl[F[_]: Async](actorSystem: ActorSystem[?]) extends Service[F, Scope]:

--- a/tracking-actors/src/main/scala/io/github/positionpal/location/tracking/actors/BorerAkkaSerializer.scala
+++ b/tracking-actors/src/main/scala/io/github/positionpal/location/tracking/actors/BorerAkkaSerializer.scala
@@ -25,8 +25,8 @@ class BorerAkkaSerializer(system: ExtendedActorSystem) extends BorerCborAkkaSeri
     deriveCodec[RealTimeUserTracker.StatefulDrivingEvent]
   given ignoreCoded: Codec[RealTimeUserTracker.Ignore.type] = deriveCodec[RealTimeUserTracker.Ignore.type]
   given aliveCheckCodec: Codec[RealTimeUserTracker.AliveCheck.type] = deriveCodec[RealTimeUserTracker.AliveCheck.type]
-  given wireCodec: Codec[RealTimeUserTracker.Wire] = deriveCodec[RealTimeUserTracker.Wire]
-  given unWireCodec: Codec[RealTimeUserTracker.UnWire] = deriveCodec[RealTimeUserTracker.UnWire]
+  given wireCodec: Codec[GroupManager.Wire] = deriveCodec[GroupManager.Wire]
+  given unWireCodec: Codec[GroupManager.UnWire] = deriveCodec[GroupManager.UnWire]
 
   register[RealTimeUserTracker.AliveCheck.type]()
   register[RealTimeUserTracker.Ignore.type]()
@@ -34,5 +34,5 @@ class BorerAkkaSerializer(system: ExtendedActorSystem) extends BorerCborAkkaSeri
   register[DrivenEvent]()
   register[RealTimeUserTracker.StatefulDrivingEvent]()
   register[RealTimeUserTracker.ObservableSession]()
-  register[RealTimeUserTracker.Wire]()
-  register[RealTimeUserTracker.UnWire]()
+  register[GroupManager.Wire]()
+  register[GroupManager.UnWire]()

--- a/tracking-actors/src/main/scala/io/github/positionpal/location/tracking/actors/GroupManager.scala
+++ b/tracking-actors/src/main/scala/io/github/positionpal/location/tracking/actors/GroupManager.scala
@@ -1,0 +1,58 @@
+package io.github.positionpal.location.tracking.actors
+
+import io.github.positionpal.location.commons.ScopeFunctions.also
+import akka.persistence.typed.PersistenceId
+import akka.cluster.sharding.typed.ShardingEnvelope
+import akka.actor.typed.{ActorRef, Behavior}
+import akka.cluster.typed.Cluster
+import akka.persistence.typed.scaladsl.{Effect, EventSourcedBehavior}
+import akka.cluster.sharding.typed.scaladsl.{Entity, EntityTypeKey}
+import akka.actor.typed.scaladsl.Behaviors
+import io.github.positionpal.location.domain.DrivenEvent
+import io.github.positionpal.entities.GroupId
+
+/** An akka sharded actor that manages a group of users, acting as an intermediary
+  * between the clients and the [[RealTimeUserTracker]] actors that track the users.
+  */
+object GroupManager:
+
+  /** Uniquely identifies the types of this entity instances (actors) that will be managed by cluster sharding. */
+  val key: EntityTypeKey[Command] = EntityTypeKey(getClass.getSimpleName)
+
+  type Observer = ActorRef[DrivenEvent]
+  type Command = ProtocolCommand | DrivenEvent
+  type Event = ProtocolCommand
+
+  /** The commands that can be sent to the actor to interact with it. */
+  sealed trait ProtocolCommand extends AkkaSerializable
+
+  /** The command to attach an observer to the actor, receiving updates about the user's state. */
+  case class Wire(observer: Observer) extends ProtocolCommand
+
+  /** The command to detach an observer from the actor, stopping to receive updates about the user's state. */
+  case class UnWire(observer: Observer) extends ProtocolCommand
+
+  final case class State(observers: Set[Observer] = Set.empty) extends AkkaSerializable:
+    def update(event: DrivenEvent): State = this.also(_.observers.foreach(_ ! event))
+
+  def apply(): Entity[Command, ShardingEnvelope[Command]] =
+    Entity(key)(ctx => this(GroupId.create(ctx.entityId)))
+
+  def apply(groupId: GroupId): Behavior[Command] =
+    Behaviors.setup: ctx =>
+      ctx.log.debug("Starting GroupManager::{}@{}", groupId, Cluster(ctx.system).selfMember.address)
+      val persistenceId = PersistenceId(key.name, groupId.value())
+      EventSourcedBehavior(persistenceId, State(), commandHandler, eventHandler)
+      // .snapshotWhen((_, event, _) => event == RoutingStopped, deleteEventsOnSnapshot = true)
+      // .withRetention(snapshotEvery(numberOfEvents = 100, keepNSnapshots = 1).withDeleteEventsOnSnapshot)
+      // .onPersistFailure(restartWithBackoff(minBackoff = 2.second, maxBackoff = 15.seconds, randomFactor = 0.2))
+
+  private def commandHandler: (State, Command) => Effect[Event, State] = (state, command) =>
+    command match
+      case e: ProtocolCommand => Effect.persist(e)
+      case e: DrivenEvent => Effect.none.thenRun(_.update(e))
+
+  private def eventHandler: (State, Event) => State = (state, event) =>
+    event match
+      case Wire(observer) => state.copy(observers = state.observers + observer)
+      case UnWire(observer) => state.copy(observers = state.observers - observer)

--- a/tracking-actors/src/main/scala/io/github/positionpal/location/tracking/actors/GroupManager.scala
+++ b/tracking-actors/src/main/scala/io/github/positionpal/location/tracking/actors/GroupManager.scala
@@ -1,17 +1,18 @@
 package io.github.positionpal.location.tracking.actors
 
-import akka.actor.typed.SupervisorStrategy.restartWithBackoff
-import io.github.positionpal.location.commons.ScopeFunctions.also
+import scala.concurrent.duration.DurationInt
+
 import akka.persistence.typed.PersistenceId
 import akka.cluster.sharding.typed.ShardingEnvelope
 import akka.actor.typed.{ActorRef, Behavior}
 import akka.persistence.typed.scaladsl.{Effect, EventSourcedBehavior}
+import akka.actor.typed.SupervisorStrategy.restartWithBackoff
 import akka.cluster.sharding.typed.scaladsl.{Entity, EntityTypeKey}
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import akka.persistence.typed.scaladsl.RetentionCriteria.snapshotEvery
+import io.github.positionpal.location.commons.ScopeFunctions.also
 import io.github.positionpal.location.domain.DrivenEvent
 import io.github.positionpal.entities.GroupId
-import scala.concurrent.duration.DurationInt
 
 /** An akka sharded actor that manages a group of users, acting as an intermediary
   * between the clients and the [[RealTimeUserTracker]] actors that track the users.

--- a/tracking-actors/src/main/scala/io/github/positionpal/location/tracking/actors/RealTimeUserTracker.scala
+++ b/tracking-actors/src/main/scala/io/github/positionpal/location/tracking/actors/RealTimeUserTracker.scala
@@ -86,9 +86,10 @@ object RealTimeUserTracker:
           .onPersistFailure(restartWithBackoff(minBackoff = 2.second, maxBackoff = 15.seconds, randomFactor = 0.2))
 
   private def eventHandler(using ctx: ActorContext[Command]): (ObservableSession, Event) => ObservableSession =
-    (state, event) => event match
-      case StatefulDrivingEvent(_, e) => state.update(e)(using ctx.system)
-      case e: InternalEvent => state.update(e)(using ctx.system)
+    (state, event) =>
+      event match
+        case StatefulDrivingEvent(_, e) => state.update(e)(using ctx.system)
+        case e: InternalEvent => state.update(e)(using ctx.system)
 
   private def commandHandler(timer: TimerScheduler[Command])(using
       ActorContext[Command],

--- a/tracking-actors/src/main/scala/io/github/positionpal/location/tracking/utils/AkkaUtils.scala
+++ b/tracking-actors/src/main/scala/io/github/positionpal/location/tracking/utils/AkkaUtils.scala
@@ -9,6 +9,7 @@ import akka.actor.{BootstrapSetup, CoordinatedShutdown}
 import cats.implicits.{catsSyntaxApplicativeError, toFlatMapOps, toFunctorOps}
 import cats.effect
 import cats.effect.kernel.Async
+import akka.cluster.sharding.typed.scaladsl.{ClusterSharding, EntityRef, EntityTypeKey}
 import cats.effect.{Deferred, Resource}
 import org.slf4j.LoggerFactory
 import akka.Done
@@ -92,3 +93,13 @@ object AkkaUtils:
                   .handleErrorWith(_ => Async[F].delay(logger.warn("Timed-out waiting for Akka to terminate!")))
               yield ()
             (system, cancel)
+
+  /** Retrieves the [[EntityRef]] of an Akka Cluster Sharding entity.
+    * @param entityTypeKey The type key of the entity.
+    * @param entityId The unique identifier of the entity.
+    * @param actorSystem The actor system.
+    * @tparam T the type of the entity key.
+    * @return The entity reference of the sharded entity in the cluster.
+    */
+  def refOf[T](entityTypeKey: EntityTypeKey[T], entityId: String)(using actorSystem: ActorSystem[?]): EntityRef[T] =
+    ClusterSharding(actorSystem).entityRefFor(entityTypeKey, entityId)

--- a/tracking-actors/src/test/scala/io/github/positionpal/location/tracking/actors/RealTimeUserTrackerTest.scala
+++ b/tracking-actors/src/test/scala/io/github/positionpal/location/tracking/actors/RealTimeUserTrackerTest.scala
@@ -47,7 +47,7 @@ class RealTimeUserTrackerTest
     def notificationService: NotificationService[IO] = notifier
     def mapsService: MapsService[IO] = maps
     def initialStates(ins: List[UserState]): List[ObservableSession] =
-      ins.map(s => ObservableSession(Session.from(testScope, s, sampling(s), tracking(s)), Set.empty))
+      ins.map(s => ObservableSession(Session.from(testScope, s, sampling(s), tracking(s))))
 
   "RealTimeUserTracker" when:
     "in inactive or active state" when:

--- a/tracking-actors/src/test/scala/io/github/positionpal/location/tracking/actors/RealTimeUserTrackerTest.scala
+++ b/tracking-actors/src/test/scala/io/github/positionpal/location/tracking/actors/RealTimeUserTrackerTest.scala
@@ -1,27 +1,29 @@
 package io.github.positionpal.location.tracking.actors
 
 import java.io.File
+
 import scala.language.postfixOps
-import eu.monniot.scala3mock.scalatest.MockFactory
+
 import io.github.positionpal.location.domain.EventConversions.{*, given}
 import io.github.positionpal.location.domain.TimeUtils.*
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.cluster.Cluster
-import akka.cluster.sharding.typed.scaladsl.ClusterSharding
 import io.github.positionpal.location.application.tracking.MapsService
 import io.github.positionpal.location.domain.*
 import io.github.positionpal.location.domain.GeoUtils.*
 import io.github.positionpal.location.tracking.actors.RealTimeUserTracker.*
 import io.github.positionpal.location.domain.RoutingMode.*
 import io.github.positionpal.location.domain.UserState.*
-import org.scalatest.wordspec.AnyWordSpecLike
 import cats.effect.IO
+import akka.cluster.Cluster
+import eu.monniot.scala3mock.scalatest.MockFactory
 import io.github.positionpal.location.domain.Distance.meters
 import org.scalatest.concurrent.Eventually
 import io.github.positionpal.location.application.notifications.NotificationService
 import akka.persistence.testkit.scaladsl.EventSourcedBehaviorTestKit
 import org.scalatest.{BeforeAndAfterEach, OneInstancePerTest}
 import org.scalatest.time.{Seconds, Span}
+import org.scalatest.wordspec.AnyWordSpecLike
+import akka.cluster.sharding.typed.scaladsl.ClusterSharding
 
 class RealTimeUserTrackerTest
     extends ScalaTestWithActorTestKit(RealTimeUserTrackerTest.config)

--- a/tracking-actors/src/test/scala/io/github/positionpal/location/tracking/actors/StateVerifierDSL.scala
+++ b/tracking-actors/src/test/scala/io/github/positionpal/location/tracking/actors/StateVerifierDSL.scala
@@ -46,8 +46,8 @@ trait RealTimeUserTrackerVerifierDSL:
     ): Verification[DrivingEvent, ObservableSession] = new Verification[DrivingEvent, ObservableSession]:
       infix override def verifying(verifyLast: (DrivingEvent, ObservableSession) => Unit)(using PatienceConfig): Unit =
         val testKit = EventSourcedBehaviorTestKit[Command, Event, ObservableSession](
-          system,
-          RealTimeUserTracker(
+          system = system,
+          behavior = RealTimeUserTracker(
             scope = Scope(UserId.create("luke"), GroupId.create("astro")),
             tag = "rtut-0",
           )(using ctx.notificationService, ctx.mapsService),

--- a/ws/src/main/scala/io/github/positionpal/location/ws/handlers/v1/ConnectionsManager.scala
+++ b/ws/src/main/scala/io/github/positionpal/location/ws/handlers/v1/ConnectionsManager.scala
@@ -11,7 +11,7 @@ import io.github.positionpal.entities.{GroupId, UserId}
   */
 object ConnectionsManager:
 
-  /** A tuple of the user id and the reference to the actor in charge of their tracking in a group. */
+  /** A tuple of the user id and the reference to the actor in charge of managing the web socket connection. */
   type Connection = (UserId, ActorRef[DrivenEvent])
 
   private val activeConnections = TrieMap[GroupId, Set[Connection]]()

--- a/ws/src/test/scala/io/github/positionpal/location/ws/WebSocketsTest.scala
+++ b/ws/src/test/scala/io/github/positionpal/location/ws/WebSocketsTest.scala
@@ -73,7 +73,7 @@ class WebSocketsTest
               val group = GroupId.create("astro")
               val test = WebSocketTest(testConfig)
               val scenario = test.Scenario(
-                group = GroupId.create("test-group"),
+                group = group,
                 clients = test.Client(luke) :: test.Client(eve) :: Nil,
                 events = sample(Scope(luke, group), cesenaCampus) :: sample(Scope(eve, group), bolognaCampus) :: Nil,
               )


### PR DESCRIPTION
This PR replaces the in-memory WebSocket connections manager with a sharded actor group manager keeping track of the interested observers to user state's updates. 

This change enhances the scalability of the service by leveraging sharded actors in a cluster, which can communicate and rebalance transparently and independently from their physical location. As a result, updates through websockets will seamlessly flow to the appropriate replica of the cluster without requiring to set up additional logic in the deployment infrastructure.